### PR TITLE
Change minor syntax issue in lessons/04-core-react-concepts/C-effects.md

### DIFF
--- a/lessons/04-core-react-concepts/C-effects.md
+++ b/lessons/04-core-react-concepts/C-effects.md
@@ -1,5 +1,5 @@
 ---
-description: "useEffect is a criticl hook for React, allowing developers to do asynchronous actions like making HTTP requests"
+description: "useEffect is a critical hook for React, allowing developers to do asynchronous actions like making HTTP requests"
 ---
 
 We have enough to start making some requests now. We want the app to request an initial set of pets on initial load of the page. So let's make that happen using a special hook called `useEffect`. `useEffect` allows you to say "do a render of this component first so the user can see _something_ then as soon as the render is done, _then_ do something (the something here being an effect.) In our case, we want the user to see our UI first then we want to make a request to the API so we can that initial list of pets.
@@ -32,7 +32,7 @@ async function requestPets() {
 {
   pets.map((pet) => (
     <Pet name={pet.name} animal={pet.animal} breed={pet.breed} key={pet.id} />
-  ));
+  ))
 }
 ```
 


### PR DESCRIPTION
There is an extra semi-colon in the pets.map function call in the notes for Effects in https://react-v8.holt.courses/lessons/core-react-concepts/effects.

If we refer to https://github.com/btholt/citr-v8-project/blob/main/05-useeffect/src/SearchParams.jsx, there is no such semi colon.

![image](https://user-images.githubusercontent.com/24219264/211195613-b142e387-d440-45d4-86fe-39df48f565ef.png)

The presence of this semi-colon causes this 
![image](https://user-images.githubusercontent.com/24219264/211195711-b100666e-fddc-4a22-970e-8c52bad0b34a.png)

There is also no semi-colon in the same line in the lecture video
![image](https://user-images.githubusercontent.com/24219264/211195695-42a44fa9-9707-4fe7-aeb4-94b0ca026348.png)


