### PR TITLE
Fix app links

### DIFF
--- a/lessons/14-redux/A-redux-toolkit.md
+++ b/lessons/14-redux/A-redux-toolkit.md
@@ -160,3 +160,5 @@ const adoptedPet = useSelector((state) => state.adoptedPet.value);
 That's it! You give `useSelector` a function that takes in the entire state tree and gives back just what you need. Keep in mind this is a subscription function: it will use this function to judge whether or not it needs to re-render your component. So don't just give it `state => state` or else it'll re-render on _every state change ever_ which is likely not what you want.
 
 Again, this is all fairly similar to Context but it definitely has its upsides. Slices are easy to test. And it externalize React's app state management from React itself. This means you can treat state mutation separately from UI which is generally a good thing. RTK made this much more palatable.
+
+[app]: https://github.com/btholt/citr-v8-project/tree/master/14-context

--- a/lessons/15-testing/A-testing-react.md
+++ b/lessons/15-testing/A-testing-react.md
@@ -50,7 +50,7 @@ Now that we've got that going, let's go write a test.
 [enzyme]: http://airbnb.io/enzyme/
 [istanbul]: https://istanbul.js.org
 [res]: https://raw.githubusercontent.com/btholt/complete-intro-to-react-v5/testing/__mocks__/@frontendmasters/res.json
-[app]: https://github.com/btholt/citr-v7-project/tree/master/12-portals-and-refs
+[app]: https://github.com/btholt/citr-v8-project/tree/master/14-context
 [fb]: https://twitter.com/cpojer/status/1524419433938046977
 [hd]: https://github.com/capricorn86/happy-dom
 [vitest]: https://vitest.dev/


### PR DESCRIPTION
- Add missing app link at the top for `redux-toolkit` page
- Fix app link at the top for `testing-react` page