### PR TITLE
Fix typo in D-git lesson file

### DIFF
--- a/lessons/03-js-tools/D-git.md
+++ b/lessons/03-js-tools/D-git.md
@@ -15,6 +15,6 @@ coverage/
 .vscode/
 ```
 
-This will make it so these things won't get added to our repo. If you want more Git instruction, please check out [Nina Zakharenko's coures on Frontend Masters][nina]
+This will make it so these things won't get added to our repo. If you want more Git instruction, please check out [Nina Zakharenko's course on Frontend Masters][nina]
 
 [nina]: https://frontendmasters.com/courses/git-in-depth/


### PR DESCRIPTION
Fixed typo in D-git lesson file in 03-js-tools section.